### PR TITLE
Software Serial RX pin interrupt  is not necessary

### DIFF
--- a/cores/arduino/SoftwareSerial.cpp
+++ b/cores/arduino/SoftwareSerial.cpp
@@ -42,6 +42,7 @@
 
 void GpioEnableInt(uint32_t port, uint32_t pin, uint32_t mode);
 void GpioDisableInt(uint32_t port, uint32_t pin);
+
 //
 // Statics
 //

--- a/cores/arduino/SoftwareSerial.cpp
+++ b/cores/arduino/SoftwareSerial.cpp
@@ -160,16 +160,11 @@ inline uint32_t SoftwareSerial::rx_pin_read() {
 }
 
 inline void SoftwareSerial::tx_pin_write(uint8_t pin_state) {
-  if(pin_state) {
+  if(pin_state)
     gpio_port(LPC1768_PIN_PORT(_transmitPin)).FIOSET = util::bit_value(LPC1768_PIN_PIN(_transmitPin));
-  }
   else
-  {
     gpio_port(LPC1768_PIN_PORT(_transmitPin)).FIOCLR = util::bit_value(LPC1768_PIN_PIN(_transmitPin));
-  }
 }
-
-
 
 #ifndef USE_NO_INTERRUPT_PINS
 //

--- a/cores/arduino/SoftwareSerial.h
+++ b/cores/arduino/SoftwareSerial.h
@@ -56,7 +56,6 @@ private:
   uint32_t _receivePort;
   uint32_t _receivePortPin;
 
-
   // Expressed as 4-cycle delays (must never be 0!)
   uint16_t _rx_delay_centering;
   uint16_t _rx_delay_intrabit;

--- a/cores/arduino/SoftwareSerial.h
+++ b/cores/arduino/SoftwareSerial.h
@@ -42,6 +42,8 @@
 * Definitions
 ******************************************************************************/
 
+#define USE_NO_INTERRUPT_PINS
+
 #define _SS_MAX_RX_BUFF 64 // RX buffer size
 
 class SoftwareSerial : public Stream
@@ -87,6 +89,7 @@ public:
   SoftwareSerial(pin_t receivePin, pin_t transmitPin, bool inverse_logic = false);
   ~SoftwareSerial();
   void begin(long speed);
+  void listenReceive();
   bool listen();
   void end();
   bool isListening() { return this == active_object; }


### PR DESCRIPTION
When the "#define USE_NO_INTERRUPT_PINS" is defined in "SoftwareSerial.h", add function "listenReceive()", when "listenReceive" is running in while(1); it can receive data from RX