### PR TITLE
Enable Hardware PWM, Frequency modification

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -125,9 +125,7 @@ void randomSeed(uint32_t);
 
 char *dtostrf (double __val, signed char __width, unsigned char __prec, char *__s);
 
-constexpr int map(uint16_t x, uint16_t in_min, uint16_t in_max, uint16_t out_min, uint16_t out_max) {
-  return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
-}
+using util::map;
 
 void tone(const pin_t _pin, const uint32_t frequency, const uint32_t duration = 0);
 void noTone(const pin_t _pin);

--- a/cores/arduino/HardwarePWM.cpp
+++ b/cores/arduino/HardwarePWM.cpp
@@ -15,19 +15,38 @@
  *
  */
 
+#include <lpc17xx_clkpwr.h>
 #include "HardwarePWM.h"
 uint32_t active_pwm_pins = 0;
+uint32_t idle_pwm_pins = 0;
 
 void pwm_hardware_init(const uint32_t prescale, const uint32_t period) {
-  // Reset and set up timing
-  LPC_PWM1->TCR  = util::bit_value(1);  // reset and hold timer
-  LPC_PWM1->PR   = prescale;
-  LPC_PWM1->MR0  = 1; //todo: if the period is set correctly here then the first set of match registers doesnt work, figure out why
-  // Configure PWM
-  LPC_PWM1->MCR  = util::bit_value(1);  // Configured to reset TC if it matches MR0, No interrupts
-  LPC_PWM1->CTCR = 0;                   // Set counters to increment on prescaled timer
-  // Disable all PWM outputs and enable PWM mode
-  LPC_PWM1->PCR  = 0;                             // PWM1 control of outputs off
-  LPC_PWM1->TCR  = util::bitset_value(0, 3);      // Enable counters, Turn on PWM
-  pwm_set_period(period);                         // set and latch in period
+
+  // Power on the peripheral
+  CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCPWM1, ENABLE);
+  CLKPWR_SetPCLKDiv (CLKPWR_PCLKSEL_PWM1, CLKPWR_PCLKSEL_CCLK_DIV_4);
+
+  // Make sure it is in a clean state
+  LPC_PWM1->IR = 0xFF & PWM_IR_BITMASK;
+  LPC_PWM1->TCR = 0;
+  LPC_PWM1->CTCR = 0;
+  LPC_PWM1->MCR = 0;
+  LPC_PWM1->CCR = 0;
+  LPC_PWM1->PCR &= 0xFF00;
+  LPC_PWM1->LER = 0;
+
+  // Clock prescaler
+  LPC_PWM1->PR = prescale;
+
+  // Configured to reset TC if it matches MR0, No interrupts
+  LPC_PWM1->MCR = util::bit_value(1);
+
+  // Set the period using channel 0 before enabling peripheral
+  pwm_set_period(period);
+
+  // Enable PWM mode
+  // TODO: this is very unreliable appears to randomly miss latches thus not changing the duty cycle
+  // disabling PWM latch mode at least gives reliable (bit 3)
+  //LPC_PWM1->TCR = util::bitset_value(0, 3);      //  Turn on PWM latch mode and Enable counters
+  LPC_PWM1->TCR = util::bitset_value(0);
 }

--- a/cores/arduino/HardwarePWM.cpp
+++ b/cores/arduino/HardwarePWM.cpp
@@ -15,38 +15,7 @@
  *
  */
 
-#include <lpc17xx_clkpwr.h>
 #include "HardwarePWM.h"
-uint32_t active_pwm_pins = 0;
-uint32_t idle_pwm_pins = 0;
 
-void pwm_hardware_init(const uint32_t prescale, const uint32_t period) {
-
-  // Power on the peripheral
-  CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCPWM1, ENABLE);
-  CLKPWR_SetPCLKDiv (CLKPWR_PCLKSEL_PWM1, CLKPWR_PCLKSEL_CCLK_DIV_4);
-
-  // Make sure it is in a clean state
-  LPC_PWM1->IR = 0xFF & PWM_IR_BITMASK;
-  LPC_PWM1->TCR = 0;
-  LPC_PWM1->CTCR = 0;
-  LPC_PWM1->MCR = 0;
-  LPC_PWM1->CCR = 0;
-  LPC_PWM1->PCR &= 0xFF00;
-  LPC_PWM1->LER = 0;
-
-  // Clock prescaler
-  LPC_PWM1->PR = prescale;
-
-  // Configured to reset TC if it matches MR0, No interrupts
-  LPC_PWM1->MCR = util::bit_value(1);
-
-  // Set the period using channel 0 before enabling peripheral
-  pwm_set_period(period);
-
-  // Enable PWM mode
-  // TODO: this is very unreliable appears to randomly miss latches thus not changing the duty cycle
-  // disabling PWM latch mode at least gives reliable (bit 3)
-  //LPC_PWM1->TCR = util::bitset_value(0, 3);      //  Turn on PWM latch mode and Enable counters
-  LPC_PWM1->TCR = util::bitset_value(0);
-}
+uint32_t HardwarePWM::active_pins =  0;
+uint32_t HardwarePWM::idle_pins = 0;

--- a/cores/arduino/HardwarePWM.h
+++ b/cores/arduino/HardwarePWM.h
@@ -18,10 +18,13 @@
 #ifndef _HARDWARE_PWM_H_
 #define _HARDWARE_PWM_H_
 
+#include <time.h>
+#include <lpc17xx_pwm.h>
 #include <pinmapping.h>
 
 // 32bit bitset used to track whether a pin is activly using hardware pwm
 extern uint32_t active_pwm_pins;
+extern uint32_t idle_pwm_pins;
 
 void pwm_hardware_init(const uint32_t prescale, const uint32_t period);
 
@@ -33,13 +36,13 @@ void pwm_hardware_init(const uint32_t prescale, const uint32_t period);
 
 // return a reference to a PWM timer register using a lookup table as they are not contiguous
 [[nodiscard]] constexpr uint32_t pwm_match_lookup(const pin_t pin) noexcept {
-  constexpr uint32_t MR0_OFFSET = 24, MR4_OFFSET = 64;
-  return LPC_PWM1_BASE + (LPC1768_PIN_PWM(pin) > 3 ? MR4_OFFSET : MR0_OFFSET ) + (sizeof(uint32_t) * LPC1768_PIN_PWM(pin)) ;
+  constexpr uint32_t MR0_OFFSET = 6, MR4_OFFSET = 16;
+  return LPC_PWM1_BASE + (LPC1768_PIN_PWM(pin) > 3 ? (MR4_OFFSET + LPC1768_PIN_PWM(pin) - 4) : (MR0_OFFSET + LPC1768_PIN_PWM(pin))) * sizeof(uint32_t);
 }
 
 // return a reference to a PWM timer register using a lookup table as they are not contiguous
-[[nodiscard]] constexpr auto& pin_pwm_match(const pin_t pin) noexcept {
-   return util::memory_ref<uint32_t>(pwm_match_lookup(pin));
+[[nodiscard]] constexpr auto pin_pwm_match(const pin_t pin) noexcept {
+   return util::memory_ptr<uint32_t>(pwm_match_lookup(pin));
 }
 
 // generate a unique bit for each hardware PWM capable pin
@@ -59,14 +62,18 @@ void pwm_hardware_init(const uint32_t prescale, const uint32_t period);
 }
 
 [[gnu::always_inline]] inline void pwm_set_period(const uint32_t period) {
-  LPC_PWM1->MR0 = period - 1;               // TC resets every period cycles
-  util::bit_set(LPC_PWM1->LER, 0);
+  LPC_PWM1->TCR = util::bit_value(1);
+  LPC_PWM1->MR0 = period - 1;  // TC resets every period cycles
+  LPC_PWM1->LER = util::bit_value(0);
+  LPC_PWM1->TCR = util::bitset_value(0);
 }
 
 // update the bitset an activate hardware pwm channel for output
 [[gnu::always_inline]] inline void pwm_activate_channel(const pin_t pin) {
   util::bit_set(active_pwm_pins, pwm_pin_id(pin));         // mark the pin as active
+  util::bit_clear(idle_pwm_pins, pwm_pin_id(pin));
   util::bit_set(LPC_PWM1->PCR, 8 + LPC1768_PIN_PWM(pin));  // turn on the pins PWM output (8 offset + PWM channel)
+  pin_enable_feature(pin, pin_feature_pwm(pin));
 }
 
 // update the bitset and deactivate the hardware pwm channel
@@ -75,16 +82,44 @@ void pwm_hardware_init(const uint32_t prescale, const uint32_t period);
   if(!pwm_channel_active(pin)) util::bit_clear(LPC_PWM1->PCR, 8 + LPC1768_PIN_PWM(pin)); // turn off the PWM output
 }
 
+// update the bitset and deactivate the hardware pwm channel
+[[gnu::always_inline]] inline void pwm_idle_channel(const pin_t pin) {
+  gpio_set_output(pin); // used when at 0 duty cycle
+  util::bit_set(idle_pwm_pins, pwm_pin_id(pin));      // mark pin as inactive
+  pin_enable_feature(pin, 0);
+  gpio_clear(pin);
+}
+
 // update the match register for a channel and set the latch to update on next period
 [[gnu::always_inline]] inline void pwm_set_match(const pin_t pin, const uint32_t value) {
-  pin_pwm_match(pin) = value;
-  util::bit_set(LPC_PWM1->LER, LPC1768_PIN_PWM(pin));
+  //work around for bug if MR1 == MR0
+  *pin_pwm_match(pin) = value == LPC_PWM1->MR0 ? value + 1 : value;
+  // tried to work around latch issue by always setting all bits, was unsuccessful
+  LPC_PWM1->LER = util::bit_value(LPC1768_PIN_PWM(pin));
+
+  // At 0 duty cycle hardware pwm outputs 1 cycle pulses
+  // Work around it by disabling the pwm output and setting the pin low util the duty cycle is updated
+  if(value == 0) {
+    pwm_idle_channel(pin);
+  } else if(util::bit_test(idle_pwm_pins, pwm_pin_id(pin))) {
+    pin_enable_feature(pin, pin_feature_pwm(pin));
+    util::bit_clear(idle_pwm_pins, pwm_pin_id(pin));
+  }
 }
 
 [[gnu::always_inline]] inline void pwm_hardware_attach(pin_t pin, uint32_t value) {
   pwm_set_match(pin, value);
   pwm_activate_channel(pin);
-  pin_enable_feature(pin, pin_feature_pwm(pin));
+}
+
+[[gnu::always_inline]] inline bool pwm_hardware_detach(const pin_t pin) {
+  if (pwm_pin_active(pin)) {
+    pin_enable_feature(pin, 0); // reenable gpio
+    gpio_clear(pin);
+    pwm_deactivate_channel(pin);
+    return true;
+  }
+  return false;
 }
 
 #endif // _HARDWARE_PWM_H_

--- a/cores/arduino/HardwarePWM.h
+++ b/cores/arduino/HardwarePWM.h
@@ -18,108 +18,154 @@
 #ifndef _HARDWARE_PWM_H_
 #define _HARDWARE_PWM_H_
 
-#include <time.h>
+#include <lpc17xx_clkpwr.h>
 #include <lpc17xx_pwm.h>
 #include <pinmapping.h>
 
-// 32bit bitset used to track whether a pin is activly using hardware pwm
-extern uint32_t active_pwm_pins;
-extern uint32_t idle_pwm_pins;
-
-void pwm_hardware_init(const uint32_t prescale, const uint32_t period);
-
-// return the bits to attach the PWM hardware depending on port using a lookup table
-[[nodiscard]] constexpr int8_t pin_feature_pwm(const pin_t pin) noexcept {
-  constexpr std::array<int8_t, 5> lookup {-1, 2, 1, 3, -1};
-  return lookup[LPC1768_PIN_PORT(pin)];
-}
-
-// return a reference to a PWM timer register using a lookup table as they are not contiguous
-[[nodiscard]] constexpr uint32_t pwm_match_lookup(const pin_t pin) noexcept {
-  constexpr uint32_t MR0_OFFSET = 6, MR4_OFFSET = 16;
-  return LPC_PWM1_BASE + (LPC1768_PIN_PWM(pin) > 3 ? (MR4_OFFSET + LPC1768_PIN_PWM(pin) - 4) : (MR0_OFFSET + LPC1768_PIN_PWM(pin))) * sizeof(uint32_t);
-}
-
-// return a reference to a PWM timer register using a lookup table as they are not contiguous
-[[nodiscard]] constexpr auto pin_pwm_match(const pin_t pin) noexcept {
-   return util::memory_ptr<uint32_t>(pwm_match_lookup(pin));
-}
-
-// generate a unique bit for each hardware PWM capable pin
-[[nodiscard]] constexpr uint8_t pwm_pin_id(const pin_t pin) noexcept {
-  return (LPC1768_PIN_PORT(pin) * 6) + (LPC1768_PIN_PWM(pin) - 1);
-}
-
-// return true if a pwm channel is already attached to a pin
-[[nodiscard]] constexpr bool pwm_channel_active(const pin_t pin) noexcept {
-  const uint32_t channel = LPC1768_PIN_PWM(pin) - 1;
-  return LPC1768_PIN_PWM(pin) && util::bitset_mask(active_pwm_pins, util::bitset_value(6 + channel, 2 * 6 + channel, 3 * 6 + channel));
-}
-
-// return true if a pin is already attached to PWM hardware
-[[nodiscard]] constexpr bool pwm_pin_active(const pin_t pin) noexcept {
-  return LPC1768_PIN_PWM(pin) && util::bit_test(active_pwm_pins, pwm_pin_id(pin));
-}
-
-[[gnu::always_inline]] inline void pwm_set_period(const uint32_t period) {
-  LPC_PWM1->TCR = util::bit_value(1);
-  LPC_PWM1->MR0 = period - 1;  // TC resets every period cycles
-  LPC_PWM1->LER = util::bit_value(0);
-  LPC_PWM1->TCR = util::bitset_value(0);
-}
-
-// update the bitset an activate hardware pwm channel for output
-[[gnu::always_inline]] inline void pwm_activate_channel(const pin_t pin) {
-  util::bit_set(active_pwm_pins, pwm_pin_id(pin));         // mark the pin as active
-  util::bit_clear(idle_pwm_pins, pwm_pin_id(pin));
-  util::bit_set(LPC_PWM1->PCR, 8 + LPC1768_PIN_PWM(pin));  // turn on the pins PWM output (8 offset + PWM channel)
-  pin_enable_feature(pin, pin_feature_pwm(pin));
-}
-
-// update the bitset and deactivate the hardware pwm channel
-[[gnu::always_inline]] inline void pwm_deactivate_channel(const pin_t pin) {
-  util::bit_clear(active_pwm_pins, pwm_pin_id(pin));      // mark pin as inactive
-  if(!pwm_channel_active(pin)) util::bit_clear(LPC_PWM1->PCR, 8 + LPC1768_PIN_PWM(pin)); // turn off the PWM output
-}
-
-// update the bitset and deactivate the hardware pwm channel
-[[gnu::always_inline]] inline void pwm_idle_channel(const pin_t pin) {
-  gpio_set_output(pin); // used when at 0 duty cycle
-  util::bit_set(idle_pwm_pins, pwm_pin_id(pin));      // mark pin as inactive
-  pin_enable_feature(pin, 0);
-  gpio_clear(pin);
-}
-
-// update the match register for a channel and set the latch to update on next period
-[[gnu::always_inline]] inline void pwm_set_match(const pin_t pin, const uint32_t value) {
-  //work around for bug if MR1 == MR0
-  *pin_pwm_match(pin) = value == LPC_PWM1->MR0 ? value + 1 : value;
-  // tried to work around latch issue by always setting all bits, was unsuccessful
-  LPC_PWM1->LER = util::bit_value(LPC1768_PIN_PWM(pin));
-
-  // At 0 duty cycle hardware pwm outputs 1 cycle pulses
-  // Work around it by disabling the pwm output and setting the pin low util the duty cycle is updated
-  if(value == 0) {
-    pwm_idle_channel(pin);
-  } else if(util::bit_test(idle_pwm_pins, pwm_pin_id(pin))) {
-    pin_enable_feature(pin, pin_feature_pwm(pin));
-    util::bit_clear(idle_pwm_pins, pwm_pin_id(pin));
+class HardwarePWM {
+  // return the bits to attach the PWM hardware depending on port using a lookup table
+  [[nodiscard]] static constexpr int8_t pwm_feature_index(const pin_t pin) noexcept {
+    constexpr std::array<int8_t, 5> lookup {-1, 2, 1, 3, -1};
+    return lookup[LPC1768_PIN_PORT(pin)];
   }
-}
 
-[[gnu::always_inline]] inline void pwm_hardware_attach(pin_t pin, uint32_t value) {
-  pwm_set_match(pin, value);
-  pwm_activate_channel(pin);
-}
+  // return a reference to a PWM timer register using a lookup table as they are not contiguous
+  [[nodiscard]] static constexpr uint32_t match_register_lookup(const pin_t pin) noexcept {
+    constexpr uint32_t MR0_OFFSET = 6, MR4_OFFSET = 16;
+    return LPC_PWM1_BASE + (LPC1768_PIN_PWM(pin) > 3 ? (MR4_OFFSET + LPC1768_PIN_PWM(pin) - 4) : (MR0_OFFSET + LPC1768_PIN_PWM(pin))) * sizeof(uint32_t);
+  }
 
-[[gnu::always_inline]] inline bool pwm_hardware_detach(const pin_t pin) {
-  if (pwm_pin_active(pin)) {
-    pin_enable_feature(pin, 0); // reenable gpio
+  // return a reference to a PWM timer register using a lookup table as they are not contiguous
+  [[nodiscard]] static constexpr auto match_register_ptr(const pin_t pin) noexcept {
+    return util::memory_ptr<uint32_t>(match_register_lookup(pin));
+  }
+
+  // generate a unique bit for each hardware PWM capable pin
+  [[nodiscard]] static constexpr uint8_t get_pin_id(const pin_t pin) noexcept {
+    return (LPC1768_PIN_PORT(pin) * 6) + (LPC1768_PIN_PWM(pin) - 1);
+  }
+
+  // update the bitset an activate hardware pwm channel for output
+  static inline void activate_channel(const pin_t pin) {
+    util::bit_set(active_pins, get_pin_id(pin));         // mark the pin as active
+    util::bit_clear(idle_pins, get_pin_id(pin));
+    util::bit_set(LPC_PWM1->PCR, 8 + LPC1768_PIN_PWM(pin));  // turn on the pins PWM output (8 offset + PWM channel)
+    pin_enable_feature(pin, pwm_feature_index(pin));
+  }
+
+  // update the bitset and deactivate the hardware pwm channel
+  static inline void deactivate_channel(const pin_t pin) {
+    util::bit_clear(active_pins, get_pin_id(pin));      // mark pin as inactive
+    if(!channel_active(pin)) util::bit_clear(LPC_PWM1->PCR, 8 + LPC1768_PIN_PWM(pin)); // turn off the PWM output
+  }
+
+  // update the bitset and deactivate the hardware pwm channel
+  static inline void set_idle(const pin_t pin) {
+    gpio_set_output(pin); // used when at 0 duty cycle
+    util::bit_set(idle_pins, get_pin_id(pin));      // mark pin as inactive
+    pin_enable_feature(pin, 0);
     gpio_clear(pin);
-    pwm_deactivate_channel(pin);
-    return true;
   }
-  return false;
-}
+
+public:
+  //static void init(const uint32_t prescale, const uint32_t period) {
+  static void init(const uint32_t frequency) {
+    // Power on the peripheral
+    CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCPWM1, ENABLE);
+    CLKPWR_SetPCLKDiv (CLKPWR_PCLKSEL_PWM1, CLKPWR_PCLKSEL_CCLK_DIV_4);
+
+    // Make sure it is in a clean state
+    LPC_PWM1->IR = 0xFF & PWM_IR_BITMASK;
+    LPC_PWM1->TCR = 0;
+    LPC_PWM1->CTCR = 0;
+    LPC_PWM1->MCR = 0;
+    LPC_PWM1->CCR = 0;
+    LPC_PWM1->PCR &= 0xFF00;
+    LPC_PWM1->LER = 0;
+
+    // Clock prescaler
+    LPC_PWM1->PR = 0; // (CLKPWR_GetPCLK(CLKPWR_PCLKSEL_PWM1) / 1000000) - 1; // Prescalar to create 1 MHz output
+
+    // Configured to reset TC if it matches MR0, No interrupts
+    LPC_PWM1->MCR = util::bit_value(1);
+
+    // Set the period using channel 0 before enabling peripheral
+    LPC_PWM1->MR0 = (CLKPWR_GetPCLK(CLKPWR_PCLKSEL_PWM1) / frequency) - 1;
+    LPC_PWM1->LER = util::bit_value(0); // if only latching worked
+
+    // Enable PWM mode
+    // TODO: this is very unreliable appears to randomly miss latches thus not changing the duty cycle
+    // disabling PWM latch mode at least gives reliable (bit 3)
+    //LPC_PWM1->TCR = util::bitset_value(0, 3);      //  Turn on PWM latch mode and Enable counters
+    LPC_PWM1->TCR = util::bitset_value(0);
+  }
+
+  // return true if a pwm channel is already attached to a pin
+  [[nodiscard]] static constexpr bool channel_active(const pin_t pin) noexcept {
+    const uint32_t channel = LPC1768_PIN_PWM(pin) - 1;
+    return LPC1768_PIN_PWM(pin) && util::bitset_mask(active_pins, util::bitset_value(6 + channel, 2 * 6 + channel, 3 * 6 + channel));
+  }
+
+  // return true if a pin is already attached to PWM hardware
+  [[nodiscard]] static constexpr bool pin_active(const pin_t pin) noexcept {
+    return LPC1768_PIN_PWM(pin) && util::bit_test(active_pins, get_pin_id(pin));
+  }
+
+  static inline void set_frequency(const uint32_t frequency) {
+    set_period(CLKPWR_GetPCLK(CLKPWR_PCLKSEL_PWM1) / frequency);
+  }
+
+  static inline void set_period(const uint32_t period) {
+    LPC_PWM1->TCR = util::bit_value(1);
+    LPC_PWM1->MR0 = period - 1;  // TC resets every period cycles
+    LPC_PWM1->LER = util::bit_value(0);
+    LPC_PWM1->TCR = util::bitset_value(0);
+  }
+
+  static inline uint32_t get_period() {
+    return LPC_PWM1->MR0 + 1;
+  }
+
+  static inline void set_us(const pin_t pin, const uint32_t value) {
+    set_match(pin, (CLKPWR_GetPCLK(CLKPWR_PCLKSEL_PWM1) / 1000000) * value);
+  }
+
+  // update the match register for a channel and set the latch to update on next period
+  static inline void set_match(const pin_t pin, const uint32_t value) {
+    //work around for bug if MR1 == MR0
+    *match_register_ptr(pin) = value == LPC_PWM1->MR0 ? value + 1 : value;
+    // tried to work around latch issue by always setting all bits, was unsuccessful
+    LPC_PWM1->LER = util::bit_value(LPC1768_PIN_PWM(pin));
+
+    // At 0 duty cycle hardware pwm outputs 1 cycle pulses
+    // Work around it by disabling the pwm output and setting the pin low util the duty cycle is updated
+    if(value == 0) {
+      set_idle(pin);
+    } else if(util::bit_test(idle_pins, get_pin_id(pin))) {
+      pin_enable_feature(pin, pwm_feature_index(pin));
+      util::bit_clear(idle_pins, get_pin_id(pin));
+    }
+  }
+
+  static inline void attach(const pin_t pin, const uint32_t value) {
+    set_match(pin, value);
+    activate_channel(pin);
+  }
+
+  static inline bool detach(const pin_t pin) {
+    if (pin_active(pin)) {
+      pin_enable_feature(pin, 0); // reenable gpio
+      gpio_clear(pin);
+      deactivate_channel(pin);
+      return true;
+    }
+    return false;
+  }
+
+private:
+  // 32bit bitset used to track whether a pin is activly using hardware pwm
+  static uint32_t active_pins;
+  static uint32_t idle_pins;
+};
 
 #endif // _HARDWARE_PWM_H_

--- a/cores/arduino/SoftwarePWM.cpp
+++ b/cores/arduino/SoftwarePWM.cpp
@@ -1,6 +1,6 @@
 #include <SoftwarePWM.h>
 
-SoftwarePwmTable<PWM_MAX_SOFTWARE_CHANNELS> SoftwarePWM {};
+SoftwarePwmTable<PWM_MAX_SOFTWARE_CHANNELS> SoftwarePWM::data_table {};
 
 struct PwmFrameItem { pin_t pin = P_NC; uint32_t match = 0; };
 std::array<PwmFrameItem, PWM_MAX_SOFTWARE_CHANNELS> pwm_frame;  // need to cache data for the frame to avoid out of frame transitions (160 bytes @ 20 software pwm pins!)
@@ -30,7 +30,7 @@ extern "C" void TIMER3_IRQHandler(void) {
     // reset all channels
     auto frame_it = pwm_frame.begin();
     // iterate through the attached pin list building (latching in) this frames data list, execution increases linearly with number of active software pins
-    for (SwPwmData* it = SoftwarePWM.swpwm_table_head; it != nullptr; it = it->next) {
+    for (SwPwmData* it = SoftwarePWM::data(); it != nullptr; it = it->next) {
       if(it->value > 0) {
         gpio_set(it->pin);  // set the pin high for the start of this frame
         frame_it->pin = it->pin;

--- a/cores/arduino/SoftwarePWM.h
+++ b/cores/arduino/SoftwarePWM.h
@@ -22,7 +22,7 @@
 #include <pinmapping.h>
 
 constexpr uint32_t PWM_MAX_SOFTWARE_CHANNELS = 20;
-constexpr uint32_t PWM_MATCH_OFFSET = 2; // in ticks (default prescaler makes this microseconds)
+constexpr uint32_t PWM_MATCH_OFFSET = 25; // in timer cycles (25MHz) 1us
 
 struct SwPwmData{ // 14bytes double linked list node, (16 with packing)
   pin_t pin = P_NC;
@@ -45,34 +45,6 @@ struct SoftwarePwmTable {
     for(std::size_t i = 0; i < swpwm_pin_table.size() - 1; ++i) {
       swpwm_pin_table[i].next = &swpwm_pin_table[i + 1];
     }
-  }
-
-  void init(const uint32_t frequency, const uint32_t int_priority = 2) {
-    // Setup timer for Timer3 Interrupt controlled PWM
-    LPC_SC->PCONP |= 1 << 23;                 // power on timer3
-    LPC_TIM3->PR = 0; // no prescaler
-    LPC_TIM3->MCR = util::bitset_value(0, 1); // Interrupt on MR0, reset on MR0
-    LPC_TIM3->MR0 = (CLKPWR_GetPCLK(CLKPWR_PCLKSEL_TIMER3) / frequency) - 1; // set frequency
-    LPC_TIM3->TCR = util::bit_value(0);       // enable the timer
-
-    NVIC_SetPriority(TIMER3_IRQn, NVIC_EncodePriority(0, int_priority, 0));
-  }
-
-  void set_frequency(const uint32_t frequency){
-    set_period(CLKPWR_GetPCLK(CLKPWR_PCLKSEL_TIMER3) / frequency);
-  }
-
-  void set_period(const uint32_t period) {
-    LPC_TIM3->MR0 = period - 1;
-    LPC_TIM3->TC = period - 2;
-  }
-
-  uint32_t get_period() {
-    return LPC_TIM3->MR0 + 1;
-  }
-
-  constexpr uint32_t size() {
-    return length;
   }
 
   constexpr bool exists(const pin_t pin) {
@@ -184,6 +156,76 @@ struct SoftwarePwmTable {
   }
 };
 
-extern SoftwarePwmTable<PWM_MAX_SOFTWARE_CHANNELS> SoftwarePWM;
+class SoftwarePWM {
+public:
+  static void init(const uint32_t frequency, const uint32_t int_priority = 2) {
+    // Setup timer for Timer3 Interrupt controlled PWM
+    LPC_SC->PCONP |= 1 << 23;                 // power on timer3
+    LPC_TIM3->PR = 0; // no prescaler
+    LPC_TIM3->MCR = util::bitset_value(0, 1); // Interrupt on MR0, reset on MR0
+    LPC_TIM3->MR0 = (CLKPWR_GetPCLK(CLKPWR_PCLKSEL_TIMER3) / frequency) - 1; // set frequency
+    LPC_TIM3->TCR = util::bit_value(0);       // enable the timer
+
+    NVIC_SetPriority(TIMER3_IRQn, NVIC_EncodePriority(0, int_priority, 0));
+  }
+
+  static void set_frequency(const uint32_t frequency){
+    set_period(CLKPWR_GetPCLK(CLKPWR_PCLKSEL_TIMER3) / frequency);
+  }
+
+  static void set_period(const uint32_t period) {
+    uint32_t old_period = LPC_TIM3->MR0;
+    LPC_TIM3->MR0 = period - 1;
+    LPC_TIM3->TC = util::map(LPC_TIM3->TC, 0, old_period, 0, LPC_TIM3->MR0);
+    if (LPC_TIM3->TC > LPC_TIM3->MR0) {
+      LPC_TIM3->TC = LPC_TIM3->MR0 - 1;
+    }
+  }
+
+  static uint32_t get_period() {
+    return LPC_TIM3->MR0 + 1;
+  }
+
+  static uint32_t size() {
+    return data_table.length;
+  }
+
+  static SwPwmData* data() {
+    return data_table.swpwm_table_head;
+  }
+
+  [[nodiscard]] static bool available(const pin_t pin) {
+    return data_table.swpwm_table_free != nullptr;
+  }
+
+  [[nodiscard]] static bool active(const pin_t pin) {
+    return data_table.exists(pin);
+  }
+
+  static void set_us(const pin_t pin, const uint32_t value) {
+    set_match(pin, (CLKPWR_GetPCLK(CLKPWR_PCLKSEL_TIMER3) / 1000000) * value);
+  }
+
+  static void set_match(const pin_t pin, const uint32_t value) {
+    data_table.update(pin, value);
+  }
+
+  static bool attach(const pin_t pin, const uint32_t value) {
+    if (data_table.update(pin, value)) {
+      gpio_set_output(pin);
+      gpio_clear(pin);
+      pin_enable_feature(pin, 0);            // initialise pin for gpio output
+      return true;
+    }
+    return false;
+  }
+
+  static bool detach(const pin_t pin) {
+    return data_table.remove(pin);
+  }
+
+private:
+  static SoftwarePwmTable<PWM_MAX_SOFTWARE_CHANNELS> data_table;
+};
 
 #endif // _SOFTWARE_PWM_H_

--- a/cores/arduino/arduino.cpp
+++ b/cores/arduino/arduino.cpp
@@ -116,7 +116,7 @@ void analogWrite(pin_t pin, int pwm_value) {  // 1 - 254: pwm_value, 0: LOW, 255
 
   util::limit(pwm_value, 0, 255);
   if (pwm_attach_pin(pin)) {
-    pwm_write(pin, map(pwm_value, 0, 255, 0, 20000));  // map 1-254 onto PWM range
+    pwm_write_ratio(pin, (uint8_t)pwm_value);  // map 1-254 onto PWM range
   } else {
     digitalWrite(pin, pwm_value);  // treat as a digital pin if out of channels
   }

--- a/cores/arduino/const_functions.h
+++ b/cores/arduino/const_functions.h
@@ -107,15 +107,15 @@ template<typename T>
   return reinterpret_cast<volatile T*>(loc);
 }
 
+template<typename T>
+[[nodiscard]] constexpr auto& memory_ref(const std::size_t loc) {
+  return *reinterpret_cast<volatile T*>(loc);
+}
+
 [[nodiscard]] constexpr uint32_t map(uint32_t x, uint32_t in_min, uint32_t in_max, uint32_t out_min, uint32_t out_max) noexcept{
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
 
-// TODO: debug why this gets optimised away under some circumstances.
-// template<typename T>
-// [[nodiscard]] constexpr volatile T& memory_ref(const std::size_t loc) {
-//   return *reinterpret_cast<volatile T*>(loc);
-// }
 
 #define _BV(n) (1<<(n))
 #define TEST(n,b) !!((n)&_BV(b))

--- a/cores/arduino/const_functions.h
+++ b/cores/arduino/const_functions.h
@@ -104,13 +104,14 @@ template <typename Value, typename BitSet>
 
 template<typename T>
 [[nodiscard]] constexpr auto memory_ptr(const std::size_t loc) {
-  return reinterpret_cast<volatile T(*)>(loc);
+  return reinterpret_cast<volatile T*>(loc);
 }
 
-template<typename T>
-[[nodiscard]] constexpr auto& memory_ref(const std::size_t loc) {
-  return *reinterpret_cast<volatile T(*)>(loc);
-}
+// TODO: debug why this gets optimised away under some circumstances.
+// template<typename T>
+// [[nodiscard]] constexpr volatile T& memory_ref(const std::size_t loc) {
+//   return *reinterpret_cast<volatile T*>(loc);
+// }
 
 #define _BV(n) (1<<(n))
 #define TEST(n,b) !!((n)&_BV(b))

--- a/cores/arduino/const_functions.h
+++ b/cores/arduino/const_functions.h
@@ -107,6 +107,10 @@ template<typename T>
   return reinterpret_cast<volatile T*>(loc);
 }
 
+[[nodiscard]] constexpr uint32_t map(uint32_t x, uint32_t in_min, uint32_t in_max, uint32_t out_min, uint32_t out_max) noexcept{
+  return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+}
+
 // TODO: debug why this gets optimised away under some circumstances.
 // template<typename T>
 // [[nodiscard]] constexpr volatile T& memory_ref(const std::size_t loc) {

--- a/cores/arduino/pinmapping.h
+++ b/cores/arduino/pinmapping.h
@@ -266,47 +266,47 @@ constexpr uint32_t pin_feature_bits(const pin_t pin, const uint8_t feature) {
   return feature << (LPC1768_PIN_PIN(pin) < 16 ? LPC1768_PIN_PIN(pin) : LPC1768_PIN_PIN(pin) - 16) * 2;
 }
 
-constexpr auto& pin_feature_reg(const pin_t pin) {
-  return util::memory_ref<uint32_t>(LPC_PINCON_BASE + (sizeof(uint32_t) * ((LPC1768_PIN_PORT(pin) * 2) + (LPC1768_PIN_PIN(pin) > 15))) );
+constexpr auto pin_feature_reg(const pin_t pin) {
+  return util::memory_ptr<uint32_t>(LPC_PINCON_BASE + (sizeof(uint32_t) * ((LPC1768_PIN_PORT(pin) * 2) + (LPC1768_PIN_PIN(pin) > 15))) );
 }
 
-[[gnu::always_inline]] inline void pin_enable_feature(const pin_t pin, uint8_t feature) {
+constexpr void pin_enable_feature(const pin_t pin, uint8_t feature) {
   auto feature_reg = pin_feature_reg(pin);
-  util::bitset_clear(feature_reg, pin_feature_bits(pin, 0b11));
-  util::bitset_set(feature_reg, pin_feature_bits(pin, feature));
+  util::bitset_clear(*feature_reg, pin_feature_bits(pin, 0b11));
+  util::bitset_set(*feature_reg, pin_feature_bits(pin, feature));
 }
 
-constexpr auto& gpio_port(uint8_t port) {
+constexpr auto gpio_port(uint8_t port) {
   constexpr std::size_t LPC_PORT_OFFSET = 0x0020;
-  return util::memory_ref<LPC_GPIO_TypeDef>(LPC_GPIO0_BASE + LPC_PORT_OFFSET * port);
+  return util::memory_ptr<LPC_GPIO_TypeDef>(LPC_GPIO0_BASE + LPC_PORT_OFFSET * port);
 }
 
 [[gnu::always_inline]] inline void gpio_set_input(const pin_t pin) {
-  util::bit_clear(gpio_port(LPC1768_PIN_PORT(pin)).FIODIR, LPC1768_PIN_PIN(pin));
+  util::bit_clear(gpio_port(LPC1768_PIN_PORT(pin))->FIODIR, LPC1768_PIN_PIN(pin));
 }
 
 [[gnu::always_inline]] inline void gpio_set_output(const pin_t pin) {
-  util::bit_set(gpio_port(LPC1768_PIN_PORT(pin)).FIODIR, LPC1768_PIN_PIN(pin));
+  util::bit_set(gpio_port(LPC1768_PIN_PORT(pin))->FIODIR, LPC1768_PIN_PIN(pin));
 }
 
 [[gnu::always_inline]] inline bool gpio_get_dir(const pin_t pin) {
-  return util::bit_test(gpio_port(LPC1768_PIN_PORT(pin)).FIODIR, LPC1768_PIN_PIN(pin));
+  return util::bit_test(gpio_port(LPC1768_PIN_PORT(pin))->FIODIR, LPC1768_PIN_PIN(pin));
 }
 
 [[gnu::always_inline]] inline void gpio_set(const pin_t pin) {
-  gpio_port(LPC1768_PIN_PORT(pin)).FIOSET = util::bit_value(LPC1768_PIN_PIN(pin));
+  gpio_port(LPC1768_PIN_PORT(pin))->FIOSET = util::bit_value(LPC1768_PIN_PIN(pin));
 }
 
 [[gnu::always_inline]] inline void gpio_set_port(const uint8_t port, const uint32_t pinmap) {
-  gpio_port(port).FIOSET = pinmap;
+  gpio_port(port)->FIOSET = pinmap;
 }
 
 [[gnu::always_inline]] inline void gpio_clear(const pin_t pin) {
-  gpio_port(LPC1768_PIN_PORT(pin)).FIOCLR = util::bit_value(LPC1768_PIN_PIN(pin));
+  gpio_port(LPC1768_PIN_PORT(pin))->FIOCLR = util::bit_value(LPC1768_PIN_PIN(pin));
 }
 
 [[gnu::always_inline]] inline void gpio_clear_port(const uint8_t port, const uint32_t pinmap) {
-  gpio_port(port).FIOCLR = pinmap;
+  gpio_port(port)->FIOCLR = pinmap;
 }
 
 [[gnu::always_inline]] inline void gpio_set(const pin_t pin, const bool value) {
@@ -314,7 +314,7 @@ constexpr auto& gpio_port(uint8_t port) {
 }
 
 [[gnu::always_inline]] inline bool gpio_get(const pin_t pin) {
-  return util::bit_test(gpio_port(LPC1768_PIN_PORT(pin)).FIOPIN, LPC1768_PIN_PIN(pin));
+  return util::bit_test(gpio_port(LPC1768_PIN_PORT(pin))->FIOPIN, LPC1768_PIN_PIN(pin));
 }
 
 [[gnu::always_inline]] inline void gpio_toggle(const pin_t pin) {

--- a/cores/arduino/pwm.h
+++ b/cores/arduino/pwm.h
@@ -20,7 +20,7 @@
 
 #include <pinmapping.h>
 
-void pwm_init(void);
+void pwm_init(const uint32_t frequency = 50);
 bool pwm_attach_pin(const pin_t pin, const uint32_t value = 0);
 bool pwm_write(const pin_t pin, const uint32_t value);
 bool pwm_write_ratio(const pin_t pin, const uint8_t value);

--- a/cores/arduino/pwm.h
+++ b/cores/arduino/pwm.h
@@ -23,6 +23,9 @@
 void pwm_init(void);
 bool pwm_attach_pin(const pin_t pin, const uint32_t value = 0);
 bool pwm_write(const pin_t pin, const uint32_t value);
+bool pwm_write_ratio(const pin_t pin, const uint8_t value);
+bool pwm_write_ratio(const pin_t pin, const float value);
+bool pwm_write_us(const pin_t pin, const uint32_t value);
 bool pwm_detach_pin(const pin_t pin);
 
 #endif // _LPC1768_PWM_H_

--- a/libraries/Servo/src/Servo.cpp
+++ b/libraries/Servo/src/Servo.cpp
@@ -105,11 +105,9 @@ void Servo::writeMicroseconds(int value) {
   if (channel < MAX_SERVOS) {  // ensure channel is valid
     // ensure pulse width is valid
     value = std::clamp(value, SERVO_MIN(), SERVO_MAX()) - (TRIM_DURATION);
-    value = US_TO_PULSE_WIDTH(value);  // convert to pulse_width after compensating for interrupt overhead - 12 Aug 2009
-
     servo_info[channel].pulse_width = value;
     pwm_attach_pin(servo_info[this->servoIndex].Pin.nbr);
-    pwm_write(servo_info[this->servoIndex].Pin.nbr, value);
+    pwm_write_us(servo_info[this->servoIndex].Pin.nbr, value);
   }
 }
 


### PR DESCRIPTION
Hardware PWM channels are enabled again, although latching needed disabled for reliable function, needs further investigation.

Added the framework for changing the frequency of both Software and Hardware PWM, Hardware PWM will run upto 100KHz and maintain 256 levels, overhead of Software PWM would be a problem even in simple applications above 10KHz.