### PR TITLE
Set the I2C master address to 1 if not already defined.

### DIFF
--- a/cores/arduino/Wire.cpp
+++ b/cores/arduino/Wire.cpp
@@ -28,7 +28,9 @@ extern "C" {
 
 #include <Wire.h>
 
-#define USEDI2CDEV_M 1
+#ifndef USEDI2CDEV_M
+  #define USEDI2CDEV_M 1
+#endif
 
 #if (USEDI2CDEV_M == 0)
   #define I2CDEV_M LPC_I2C0


### PR DESCRIPTION
Hi,

The goal of this pull request is to set the I2C master id to 1 by default **only** if it hasn't been already defined.

Regards,
Orel