### PR TITLE
Change the pin function id for uart3

### DIFF
--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -103,8 +103,8 @@ public:
       PinCfg.Pinnum = 11;
       PINSEL_ConfigPin(&PinCfg);
     } else if (UARTx == LPC_UART3) {
-      // Initialize UART2 pin connect
-      PinCfg.Funcnum = 1;
+      // Initialize UART3 pin connect
+      PinCfg.Funcnum = 2;
       PinCfg.OpenDrain = 0;
       PinCfg.Pinmode = 0;
       PinCfg.Pinnum = 0;


### PR DESCRIPTION
Hi,

It seems the pin function id for uart3 is wrong in the current fmk version.
Indeed, according to the [lpc176x user guide](https://www.nxp.com/docs/en/user-guide/UM10360.pdf) (page 118/851, section 8.5.1), the pin function must be set to **10**=2 to use tx3/rx3 feature on P0[0]/P0[1].

Regards,
Orel