### PR TITLE
UARTs: select pins choosen by manufacturer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,43 +7,42 @@ this is a work in progress with most basic functionality available.
 
 ### Hardware Serial Ports
 
-Without any #define, the pins are selected as with "no define".
-If your board uses other these default pins for RX/TX, set the appropriate #define(s) as in the tables below.
+If your board layout does not use the default pins for UART RX/TX override them with the definitions below.
 
 | Serial | TX | RX | FUNCNUM |
 | --- | --- | --- | --- |
-| no define | P0_02 | P0_03 | 1 |
- 
+| Default | P0_02 | P0_03 | 1 |
+
 
 | Serial1 | TX | RX | FUNCNUM |
 | --- | --- | --- | --- |
-| no define | P0_15 | P0_16 | 1 | 
-| UART1_P2_00 | P2_00 | P2_01 | 2 | 
+| Default | P0_15 | P0_16 | 1 |
+| `LPC_PINCFG_UART1_P2_00` | P2_00 | P2_01 | 2 |
 
 | Serial2 | TX | RX | FUNCNUM |
 | --- | --- | --- | --- |
-| no define | P0_10 | P0_11 | 1 | 
-| UART2_P2_08 | P2_08 | P2_09 | 2 |  
+| Default | P0_10 | P0_11 | 1 |
+| `LPC_PINCFG_UART2_P2_08` | P2_08 | P2_09 | 2 |
 
 | Serial3 | TX | RX | FUNCNUM |
 | --- | --- | --- | --- |
-| no define | P0_00 | P0_01 | 2 |
-| UART3_P0_25 | P0_25 | P0_26 | 3 |
-| UART3_P4_28 | P4_28 | P4_29 | 3 |
+| Default | P0_00 | P0_01 | 2 |
+| `LPC_PINCFG_UART3_P0_25` | P0_25 | P0_26 | 3 |
+| `LPC_PINCFG_UART3_P4_28` | P4_28 | P4_29 | 3 |
 
-### AnalogRead  
-There are 8 ADC channels available  
+### AnalogRead
+There are 8 ADC channels available
 
 | Pin | Channel Number|
 | --- | --- |
-| P0_02  | 7 | 
-| P0_03 | 6 | 
-| P0_23 | 0 | 
-| P0_24 | 1 |   
-| P0_25  | 2 | 
-| P0_26 | 3 | 
-| P1_30 | 4 | 
-| P1_31 | 5 |   
+| P0_02  | 7 |
+| P0_03 | 6 |
+| P0_23 | 0 |
+| P0_24 | 1 |
+| P0_25  | 2 |
+| P0_26 | 3 |
+| P1_30 | 4 |
+| P1_31 | 5 |
 
 ### AnalogWrite
 Although all pins can be used for PWM (software mode) there are 6 Hardware PWM channels, if a hardware channel is
@@ -53,8 +52,8 @@ software and hardware share a period (default 20ms).
 | Hardware channel | Attached pins |
 | --- | --- |
 | 1 | P1_18, P2_00  |
-| 2 | P1_20, P2_01, P3_25 | 
-| 3 | P1_21, P2_02, P3_26 | 
-| 4 | P1_23, P2_03 | 
-| 5 | P1_24, P2_04 | 
-| 6 | P1_26, P2_05 |  
+| 2 | P1_20, P2_01, P3_25 |
+| 3 | P1_21, P2_02, P3_26 |
+| 4 | P1_23, P2_03 |
+| 5 | P1_24, P2_04 |
+| 6 | P1_26, P2_05 |

--- a/README.md
+++ b/README.md
@@ -6,12 +6,30 @@ The framework aims to eventually be Arduino API compatible, though Arduino libra
 this is a work in progress with most basic functionality available.
 
 ### Hardware Serial Ports
-| Port | TX | RX |
-| --- | --- | --- |
-| Serial  | P0_02 | P0_03 | 
-| Serial1 | P0_15 | P0_16 | 
-| Serial2 | P0_10 | P0_11 | 
-| Serial3 | P0_00 | P0_01 |  
+
+Without any #define, the pins are selected as with "no define".
+If your board uses other these default pins for RX/TX, set the appropriate #define(s) as in the tables below.
+
+| Serial | TX | RX | FUNCNUM |
+| --- | --- | --- | --- |
+| no define | P0_02 | P0_03 | 1 |
+ 
+
+| Serial1 | TX | RX | FUNCNUM |
+| --- | --- | --- | --- |
+| no define | P0_15 | P0_16 | 1 | 
+| UART1_P2_00 | P2_00 | P2_01 | 2 | 
+
+| Serial2 | TX | RX | FUNCNUM |
+| --- | --- | --- | --- |
+| no define | P0_10 | P0_11 | 1 | 
+| UART2_P2_08 | P2_08 | P2_09 | 2 |  
+
+| Serial3 | TX | RX | FUNCNUM |
+| --- | --- | --- | --- |
+| no define | P0_00 | P0_01 | 2 |
+| UART3_P0_25 | P0_25 | P0_26 | 3 |
+| UART3_P4_28 | P4_28 | P4_29 | 3 |
 
 ### AnalogRead  
 There are 8 ADC channels available  

--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -89,28 +89,28 @@ public:
 	  /* Because UARTs can be multiplexed to various pins and each board manufaturer can choose which pins will be used,
 	     The pins actually used can be defined with an additional symbol.
 		 
-		 For UART0: There is only one set of pins: pin 98 and 99, so no define needed
+		 For UART0: There is only one set of pins: pin 98 and 99, PORT 0-02/03, FUNC 1, so no define needed
 
-		 For UART1: 			        default is pin 62 and 63
-					define UART1_PIN_75_74 to use  pin 75 and 74
+		 For UART1: 			    default is pin 62 and 63, PORT 0-15/16, FUNC 1
+					define UART1_P2_00 to use  pin 75 and 74, PORT 2-00/01, FUNC 2
 
-		 For UART2: 			        default is pin 48 and 49
-					define UART2_PIN_65_64 to use  pin 65 and 44
+		 For UART2: 			    default is pin 48 and 49, PORT 0-10/11, FUNC 1
+					define UART2_P2_08 to use  pin 65 and 44, PORT 2-08/09, FUNC 2
 
-		 For UART3: 			        default is pin 46 and 47
-					define UART3_PIN_7_6   to use  pin  7 and  6
-					define UART3_PIN_82_85 to use  pin 82 and 85
+		 For UART3: 			    default is pin 46 and 47, PORT 0-00/01, FUNC 2
+					define UART3_P0_25 to use  pin  7 and  6, PORT 0-25/26, FUNC 3
+					define UART3_P4_28 to use  pin 82 and 85, PORT 4-28/29, FUNC 3
 	  */
 
 		                                
-	  #if defined(UART1_PIN_75_74)	//Uses the pins: 75/74
+	  #if defined(UART1_P2_00)	//Uses the pins: 75/74
 		  PinCfg.Funcnum = 2;
 		  PinCfg.Portnum = 2;
 		  PinCfg.Pinnum = 0;
 		  PINSEL_ConfigPin(&PinCfg);
 		  PinCfg.Pinnum = 1;
 		  PINSEL_ConfigPin(&PinCfg);
-	  #else							//Uses the pins: 62/63						
+	  #else					    //Uses the pins: 62/63						
 		  PinCfg.Funcnum = 1;
 		  PinCfg.Portnum = 0;
 		  PinCfg.Pinnum = 15;
@@ -122,14 +122,14 @@ public:
       // Initialize UART2 pin connect
       PinCfg.OpenDrain = 0;
       PinCfg.Pinmode = 0;
-	  #if defined(UART2_PIN_65_64)	//Uses the pins: 65/64
+	  #if defined(UART2_P2_08)	//Uses the pins: 65/64
 		  PinCfg.Funcnum = 2;
 		  PinCfg.Portnum = 2;
 		  PinCfg.Pinnum = 8;
 		  PINSEL_ConfigPin(&PinCfg);
 		  PinCfg.Pinnum = 9;
 		  PINSEL_ConfigPin(&PinCfg);
-	  #else							//Uses the default pins: 48/49
+	  #else						//Uses the default pins: 48/49
 		  PinCfg.Funcnum = 1;
 		  PinCfg.Pinnum = 10;
 		  PinCfg.Portnum = 0;
@@ -141,21 +141,21 @@ public:
       // Initialize UART3 pin connect
       PinCfg.OpenDrain = 0;
       PinCfg.Pinmode = 0;
-	  #if defined(UART3_PIN_82_85)	//Uses the pins: 82/85
+	  #if defined(UART3_P4_28)	//Uses the pins: 82/85
 		  PinCfg.Funcnum = 3;
 		  PinCfg.Portnum = 4;
 		  PinCfg.Pinnum = 28;
 		  PINSEL_ConfigPin(&PinCfg);
 		  PinCfg.Pinnum = 29;
 		  PINSEL_ConfigPin(&PinCfg);	  
-	  #elif defined(UART3_PIN_7_6)	//Uses the pins: 7/6
+	  #elif defined(UART3_P0_25) //Uses the pins: 7/6
 		  PinCfg.Funcnum = 3;
 		  PinCfg.Portnum = 0;
 		  PinCfg.Pinnum = 25;
 		  PINSEL_ConfigPin(&PinCfg);
 		  PinCfg.Pinnum = 26;
 		  PINSEL_ConfigPin(&PinCfg);
-	  #else							//Uses the default pins: 46/47
+	  #else						//Uses the default pins: 46/47
 		  PinCfg.Funcnum = 2;
 		  PinCfg.Portnum = 0;
 		  PinCfg.Pinnum = 0;

--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -40,6 +40,26 @@ extern "C" {
   #define SERIAL_RX_BUFFER_SIZE 256
 #endif
 
+#if !defined(LPC_UART_IRQ_PRIORITY)
+  #define LPC_UART_IRQ_PRIORITY 3
+#endif
+
+/*
+  UART pin configuration:
+
+  For UART0:                                 pin 98 and 99, PORT 0-02/03, FUNC 1
+
+  For UART1:                      default is pin 62 and 63, PORT 0-15/16, FUNC 1
+        define LPC_PINCFG_UART1_P2_00 to use pin 75 and 74, PORT 2-00/01, FUNC 2
+
+  For UART2:                      default is pin 48 and 49, PORT 0-10/11, FUNC 1
+        define LPC_PINCFG_UART2_P2_08 to use pin 65 and 44, PORT 2-08/09, FUNC 2
+
+  For UART3:                      default is pin 46 and 47, PORT 0-00/01, FUNC 2
+        define LPC_PINCFG_UART3_P0_25 to use pin  7 and  6, PORT 0-25/26, FUNC 3
+        define LPC_PINCFG_UART3_P4_28 to use pin 82 and 85, PORT 4-28/29, FUNC 3
+*/
+
 template <uint32_t RXB_SIZE = SERIAL_RX_BUFFER_SIZE, uint32_t TXB_SIZE = SERIAL_TX_BUFFER_SIZE>
 class HardwareSerial : public Stream {
 private:
@@ -86,83 +106,72 @@ public:
       // Initialize UART1 pin connect
       PinCfg.OpenDrain = 0;
       PinCfg.Pinmode = 0;
-	  /* Because UARTs can be multiplexed to various pins and each board manufaturer can choose which pins will be used,
-	     The pins actually used can be defined with an additional symbol.
-		 
-		 For UART0: There is only one set of pins: pin 98 and 99, PORT 0-02/03, FUNC 1, so no define needed
 
-		 For UART1: 			    default is pin 62 and 63, PORT 0-15/16, FUNC 1
-					define UART1_P2_00 to use  pin 75 and 74, PORT 2-00/01, FUNC 2
+      #if defined(LPC_PINCFG_UART1_P2_00)
+        PinCfg.Funcnum = 2;
+        PinCfg.Portnum = 2;
+        PinCfg.Pinnum = 0;
+        PINSEL_ConfigPin(&PinCfg);
+        PinCfg.Pinnum = 1;
+        PINSEL_ConfigPin(&PinCfg);
+      #else
+        PinCfg.Funcnum = 1;
+        PinCfg.Portnum = 0;
+        PinCfg.Pinnum = 15;
+        PINSEL_ConfigPin(&PinCfg);
+        PinCfg.Pinnum = 16;
+        PINSEL_ConfigPin(&PinCfg);
+      #endif
 
-		 For UART2: 			    default is pin 48 and 49, PORT 0-10/11, FUNC 1
-					define UART2_P2_08 to use  pin 65 and 44, PORT 2-08/09, FUNC 2
-
-		 For UART3: 			    default is pin 46 and 47, PORT 0-00/01, FUNC 2
-					define UART3_P0_25 to use  pin  7 and  6, PORT 0-25/26, FUNC 3
-					define UART3_P4_28 to use  pin 82 and 85, PORT 4-28/29, FUNC 3
-	  */
-
-		                                
-	  #if defined(UART1_P2_00)	//Uses the pins: 75/74
-		  PinCfg.Funcnum = 2;
-		  PinCfg.Portnum = 2;
-		  PinCfg.Pinnum = 0;
-		  PINSEL_ConfigPin(&PinCfg);
-		  PinCfg.Pinnum = 1;
-		  PINSEL_ConfigPin(&PinCfg);
-	  #else					    //Uses the pins: 62/63						
-		  PinCfg.Funcnum = 1;
-		  PinCfg.Portnum = 0;
-		  PinCfg.Pinnum = 15;
-		  PINSEL_ConfigPin(&PinCfg);
-		  PinCfg.Pinnum = 16;
-		  PINSEL_ConfigPin(&PinCfg);
-	  #endif
     } else if (UARTx == LPC_UART2) {
       // Initialize UART2 pin connect
       PinCfg.OpenDrain = 0;
       PinCfg.Pinmode = 0;
-	  #if defined(UART2_P2_08)	//Uses the pins: 65/64
-		  PinCfg.Funcnum = 2;
-		  PinCfg.Portnum = 2;
-		  PinCfg.Pinnum = 8;
-		  PINSEL_ConfigPin(&PinCfg);
-		  PinCfg.Pinnum = 9;
-		  PINSEL_ConfigPin(&PinCfg);
-	  #else						//Uses the default pins: 48/49
-		  PinCfg.Funcnum = 1;
-		  PinCfg.Pinnum = 10;
-		  PinCfg.Portnum = 0;
-		  PINSEL_ConfigPin(&PinCfg);
-		  PinCfg.Pinnum = 11;
-		  PINSEL_ConfigPin(&PinCfg);
-	  #endif
+
+      #if defined(LPC_PINCFG_UART2_P2_08)
+        PinCfg.Funcnum = 2;
+        PinCfg.Portnum = 2;
+        PinCfg.Pinnum = 8;
+        PINSEL_ConfigPin(&PinCfg);
+        PinCfg.Pinnum = 9;
+        PINSEL_ConfigPin(&PinCfg);
+      #else
+        PinCfg.Funcnum = 1;
+        PinCfg.Pinnum = 10;
+        PinCfg.Portnum = 0;
+        PINSEL_ConfigPin(&PinCfg);
+        PinCfg.Pinnum = 11;
+        PINSEL_ConfigPin(&PinCfg);
+      #endif
+
     } else if (UARTx == LPC_UART3) {
       // Initialize UART3 pin connect
       PinCfg.OpenDrain = 0;
       PinCfg.Pinmode = 0;
-	  #if defined(UART3_P4_28)	//Uses the pins: 82/85
-		  PinCfg.Funcnum = 3;
-		  PinCfg.Portnum = 4;
-		  PinCfg.Pinnum = 28;
-		  PINSEL_ConfigPin(&PinCfg);
-		  PinCfg.Pinnum = 29;
-		  PINSEL_ConfigPin(&PinCfg);	  
-	  #elif defined(UART3_P0_25) //Uses the pins: 7/6
-		  PinCfg.Funcnum = 3;
-		  PinCfg.Portnum = 0;
-		  PinCfg.Pinnum = 25;
-		  PINSEL_ConfigPin(&PinCfg);
-		  PinCfg.Pinnum = 26;
-		  PINSEL_ConfigPin(&PinCfg);
-	  #else						//Uses the default pins: 46/47
-		  PinCfg.Funcnum = 2;
-		  PinCfg.Portnum = 0;
-		  PinCfg.Pinnum = 0;
-		  PINSEL_ConfigPin(&PinCfg);
-		  PinCfg.Pinnum = 1;
-		  PINSEL_ConfigPin(&PinCfg);
-	  #endif
+
+      #if defined(LPC_PINCFG_UART3_P4_28)
+        PinCfg.Funcnum = 3;
+        PinCfg.Portnum = 4;
+        PinCfg.Pinnum = 28;
+        PINSEL_ConfigPin(&PinCfg);
+        PinCfg.Pinnum = 29;
+        PINSEL_ConfigPin(&PinCfg);
+      #elif defined(LPC_PINCFG_UART3_P0_25)
+        PinCfg.Funcnum = 3;
+        PinCfg.Portnum = 0;
+        PinCfg.Pinnum = 25;
+        PINSEL_ConfigPin(&PinCfg);
+        PinCfg.Pinnum = 26;
+        PINSEL_ConfigPin(&PinCfg);
+      #else
+        PinCfg.Funcnum = 2;
+        PinCfg.Portnum = 0;
+        PinCfg.Pinnum = 0;
+        PINSEL_ConfigPin(&PinCfg);
+        PinCfg.Pinnum = 1;
+        PINSEL_ConfigPin(&PinCfg);
+      #endif
+
     }
 
     /* Initialize UART Configuration parameter structure to default state:
@@ -192,19 +201,19 @@ public:
 
     // Set proper priority and enable interrupts
     if (UARTx == LPC_UART0) {
-      NVIC_SetPriority(UART0_IRQn, NVIC_EncodePriority(0, 3, 0));
+      NVIC_SetPriority(UART0_IRQn, NVIC_EncodePriority(0, LPC_UART_IRQ_PRIORITY, 0));
       NVIC_EnableIRQ(UART0_IRQn);
     }
     else if ((LPC_UART1_TypeDef *) UARTx == LPC_UART1) {
-      NVIC_SetPriority(UART1_IRQn, NVIC_EncodePriority(0, 3, 0));
-     NVIC_EnableIRQ(UART1_IRQn);
+      NVIC_SetPriority(UART1_IRQn, NVIC_EncodePriority(0, LPC_UART_IRQ_PRIORITY, 0));
+      NVIC_EnableIRQ(UART1_IRQn);
     }
     else if (UARTx == LPC_UART2) {
-      NVIC_SetPriority(UART2_IRQn, NVIC_EncodePriority(0, 3, 0));
+      NVIC_SetPriority(UART2_IRQn, NVIC_EncodePriority(0, LPC_UART_IRQ_PRIORITY, 0));
       NVIC_EnableIRQ(UART2_IRQn);
     }
     else if (UARTx == LPC_UART3) {
-      NVIC_SetPriority(UART3_IRQn, NVIC_EncodePriority(0, 3, 0));
+      NVIC_SetPriority(UART3_IRQn, NVIC_EncodePriority(0, LPC_UART_IRQ_PRIORITY, 0));
       NVIC_EnableIRQ(UART3_IRQn);
     }
 

--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -73,45 +73,96 @@ public:
     if (Baudrate == baudrate) return; // No need to re-initialize
 
     if (UARTx == LPC_UART0) {
-      // Initialize UART0 pin connect
-      PinCfg.Funcnum = 1;
+      // Initialize UART0 pin connect 98 and 99
       PinCfg.OpenDrain = 0;
       PinCfg.Pinmode = 0;
-      PinCfg.Pinnum = 2;
+      PinCfg.Funcnum = 1;
       PinCfg.Portnum = 0;
+      PinCfg.Pinnum = 2;
       PINSEL_ConfigPin(&PinCfg);
       PinCfg.Pinnum = 3;
       PINSEL_ConfigPin(&PinCfg);
     } else if ((LPC_UART1_TypeDef *) UARTx == LPC_UART1) {
       // Initialize UART1 pin connect
-      PinCfg.Funcnum = 1;
       PinCfg.OpenDrain = 0;
       PinCfg.Pinmode = 0;
-      PinCfg.Pinnum = 15;
-      PinCfg.Portnum = 0;
-      PINSEL_ConfigPin(&PinCfg);
-      PinCfg.Pinnum = 16;
-      PINSEL_ConfigPin(&PinCfg);
+	  /* Because UARTs can be multiplexed to various pins and each board manufaturer can choose which pins will be used,
+	     The pins actually used can be defined with an additional symbol.
+		 
+		 For UART0: There is only one set of pins: pin 98 and 99, so no define needed
+
+		 For UART1: 			        default is pin 62 and 63
+					define UART1_PIN_75_74 to use  pin 75 and 74
+
+		 For UART2: 			        default is pin 48 and 49
+					define UART2_PIN_65_64 to use  pin 65 and 44
+
+		 For UART3: 			        default is pin 46 and 47
+					define UART3_PIN_7_6   to use  pin  7 and  6
+					define UART3_PIN_82_85 to use  pin 82 and 85
+	  */
+
+		                                
+	  #if defined(UART1_PIN_75_74)	//Uses the pins: 75/74
+		  PinCfg.Funcnum = 2;
+		  PinCfg.Portnum = 2;
+		  PinCfg.Pinnum = 0;
+		  PINSEL_ConfigPin(&PinCfg);
+		  PinCfg.Pinnum = 1;
+		  PINSEL_ConfigPin(&PinCfg);
+	  #else							//Uses the pins: 62/63						
+		  PinCfg.Funcnum = 1;
+		  PinCfg.Portnum = 0;
+		  PinCfg.Pinnum = 15;
+		  PINSEL_ConfigPin(&PinCfg);
+		  PinCfg.Pinnum = 16;
+		  PINSEL_ConfigPin(&PinCfg);
+	  #endif
     } else if (UARTx == LPC_UART2) {
       // Initialize UART2 pin connect
-      PinCfg.Funcnum = 1;
       PinCfg.OpenDrain = 0;
       PinCfg.Pinmode = 0;
-      PinCfg.Pinnum = 10;
-      PinCfg.Portnum = 0;
-      PINSEL_ConfigPin(&PinCfg);
-      PinCfg.Pinnum = 11;
-      PINSEL_ConfigPin(&PinCfg);
+	  #if defined(UART2_PIN_65_64)	//Uses the pins: 65/64
+		  PinCfg.Funcnum = 2;
+		  PinCfg.Portnum = 2;
+		  PinCfg.Pinnum = 8;
+		  PINSEL_ConfigPin(&PinCfg);
+		  PinCfg.Pinnum = 9;
+		  PINSEL_ConfigPin(&PinCfg);
+	  #else							//Uses the default pins: 48/49
+		  PinCfg.Funcnum = 1;
+		  PinCfg.Pinnum = 10;
+		  PinCfg.Portnum = 0;
+		  PINSEL_ConfigPin(&PinCfg);
+		  PinCfg.Pinnum = 11;
+		  PINSEL_ConfigPin(&PinCfg);
+	  #endif
     } else if (UARTx == LPC_UART3) {
       // Initialize UART3 pin connect
-      PinCfg.Funcnum = 2;
       PinCfg.OpenDrain = 0;
       PinCfg.Pinmode = 0;
-      PinCfg.Pinnum = 0;
-      PinCfg.Portnum = 0;
-      PINSEL_ConfigPin(&PinCfg);
-      PinCfg.Pinnum = 1;
-      PINSEL_ConfigPin(&PinCfg);
+	  #if defined(UART3_PIN_82_85)	//Uses the pins: 82/85
+		  PinCfg.Funcnum = 3;
+		  PinCfg.Portnum = 4;
+		  PinCfg.Pinnum = 28;
+		  PINSEL_ConfigPin(&PinCfg);
+		  PinCfg.Pinnum = 29;
+		  PINSEL_ConfigPin(&PinCfg);	  
+	  #elif defined(UART3_PIN_7_6)	//Uses the pins: 7/6
+		  PinCfg.Funcnum = 3;
+		  PinCfg.Portnum = 0;
+		  PinCfg.Pinnum = 25;
+		  PINSEL_ConfigPin(&PinCfg);
+		  PinCfg.Pinnum = 26;
+		  PINSEL_ConfigPin(&PinCfg);
+	  #else							//Uses the default pins: 46/47
+		  PinCfg.Funcnum = 2;
+		  PinCfg.Portnum = 0;
+		  PinCfg.Pinnum = 0;
+		  PINSEL_ConfigPin(&PinCfg);
+		  PinCfg.Pinnum = 1;
+		  PINSEL_ConfigPin(&PinCfg);
+	  #endif
     }
 
     /* Initialize UART Configuration parameter structure to default state:


### PR DESCRIPTION
The LPC1769 allows functions to be multiplexed to various pins.
Board manufacturers choose which pins are used for which function.

This allows to choose any pin combination for UARTs to be defined by additional optional symbols.

It can resolve the BigTreeTech used different pins for UART3, compared to other manufaturers.

In this case defineing UART_PIN_82_85 enables UART3, which is available at the Wifi port.

The symbols per UART are:

		 For UART0: There is only one set of pins: pin 98 and 99, so no define needed

		 For UART1: 			        default is pin 62 and 63
					define UART1_PIN_75_74 to use  pin 75 and 74

		 For UART2: 			        default is pin 48 and 49
					define UART2_PIN_65_64 to use  pin 65 and 44

		 For UART3: 			        default is pin 46 and 47
					define UART3_PIN_7_6   to use  pin  7 and  6
					define UART3_PIN_82_85 to use  pin 82 and 85
DISCLASIMER

Currently I have *only* tested correct functioning of this setting for UART3 with UART3_PIN_82_85 for my BTT SKR 1.4 Turbo.
All settings were derived from the hardware documentation:
https://github.com/bigtreetech/BIGTREETECH-SKR-V1.3/blob/master/BTT%20SKR%20V1.4/Datasheet/LPC17-32-IC.pdf