### PR TITLE
Support DMA 16 bit for Memory to peripheral

### DIFF
--- a/system/CMSIS/driver/lpc17xx_gpdma.c
+++ b/system/CMSIS/driver/lpc17xx_gpdma.c
@@ -286,7 +286,7 @@ Status GPDMA_Setup(GPDMA_Channel_CFG_Type *GPDMAChannelConfig)
 						| GPDMA_DMACCxControl_DBSize((uint32_t)GPDMA_LUTPerBurst[GPDMAChannelConfig->DstConn]) \
 						| GPDMA_DMACCxControl_SWidth(GPDMAChannelConfig->TransferWidth > 0 ? GPDMAChannelConfig->TransferWidth : (uint32_t)GPDMA_LUTPerWid[GPDMAChannelConfig->DstConn]) \
 						| GPDMA_DMACCxControl_DWidth(GPDMAChannelConfig->TransferWidth > 0 ? GPDMAChannelConfig->TransferWidth : (uint32_t)GPDMA_LUTPerWid[GPDMAChannelConfig->DstConn]) \
-						| GPDMA_DMACCxControl_SI \
+						| GPDMAChannelConfig->MemoryIncrease \
 						| GPDMA_DMACCxControl_I;
 		break;
 	// Peripheral to memory

--- a/system/CMSIS/driver/lpc17xx_gpdma.c
+++ b/system/CMSIS/driver/lpc17xx_gpdma.c
@@ -284,8 +284,8 @@ Status GPDMA_Setup(GPDMA_Channel_CFG_Type *GPDMAChannelConfig)
 				= GPDMA_DMACCxControl_TransferSize((uint32_t)GPDMAChannelConfig->TransferSize) \
 						| GPDMA_DMACCxControl_SBSize((uint32_t)GPDMA_LUTPerBurst[GPDMAChannelConfig->DstConn]) \
 						| GPDMA_DMACCxControl_DBSize((uint32_t)GPDMA_LUTPerBurst[GPDMAChannelConfig->DstConn]) \
-						| GPDMA_DMACCxControl_SWidth((uint32_t)GPDMA_LUTPerWid[GPDMAChannelConfig->DstConn]) \
-						| GPDMA_DMACCxControl_DWidth((uint32_t)GPDMA_LUTPerWid[GPDMAChannelConfig->DstConn]) \
+						| GPDMA_DMACCxControl_SWidth(GPDMAChannelConfig->TransferWidth > 0 ? GPDMAChannelConfig->TransferWidth : (uint32_t)GPDMA_LUTPerWid[GPDMAChannelConfig->DstConn]) \
+						| GPDMA_DMACCxControl_DWidth(GPDMAChannelConfig->TransferWidth > 0 ? GPDMAChannelConfig->TransferWidth : (uint32_t)GPDMA_LUTPerWid[GPDMAChannelConfig->DstConn]) \
 						| GPDMA_DMACCxControl_SI \
 						| GPDMA_DMACCxControl_I;
 		break;

--- a/system/CMSIS/include/lpc17xx_gpdma.h
+++ b/system/CMSIS/include/lpc17xx_gpdma.h
@@ -381,6 +381,12 @@ typedef struct {
 	uint32_t DMALLI;		/**< Linker List Item structure data address
 							if there's no Linker List, set as '0'
 							*/
+
+	uint32_t MemoryIncrease; /** Setup Memory Increase for GPDMA_TRANSFERTYPE_M2P
+								GPDMA_DMACCxControl_SI < Source increment
+								GPDMA_DMACCxControl_DI < Destination increment
+								Or both, or None
+							 */
 } GPDMA_Channel_CFG_Type;
 
 /**


### PR DESCRIPTION
I just allow set the transfer width, so we can set it to 16 bit and use dma spi 16 bit in GPDMA_TRANSFERTYPE_M2P.

Used in the LPC marlin tft spi.