### PR TITLE
Fix no response on Serial* with high BAUDRATE

### DIFF
--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -29,6 +29,7 @@
 #include <Stream.h>
 
 extern "C" {
+  #include <lpc17xx_clkpwr.h>
   #include <lpc17xx_uart.h>
   #include "lpc17xx_pinsel.h"
 }
@@ -102,6 +103,7 @@ public:
       PINSEL_ConfigPin(&PinCfg);
       PinCfg.Pinnum = 3;
       PINSEL_ConfigPin(&PinCfg);
+      CLKPWR_SetPCLKDiv(CLKPWR_PCLKSEL_UART0, CLKPWR_PCLKSEL_CCLK_DIV_1);
     } else if ((LPC_UART1_TypeDef *) UARTx == LPC_UART1) {
       // Initialize UART1 pin connect
       PinCfg.OpenDrain = 0;
@@ -122,7 +124,7 @@ public:
         PinCfg.Pinnum = 16;
         PINSEL_ConfigPin(&PinCfg);
       #endif
-
+      CLKPWR_SetPCLKDiv(CLKPWR_PCLKSEL_UART1, CLKPWR_PCLKSEL_CCLK_DIV_1);
     } else if (UARTx == LPC_UART2) {
       // Initialize UART2 pin connect
       PinCfg.OpenDrain = 0;
@@ -143,7 +145,7 @@ public:
         PinCfg.Pinnum = 11;
         PINSEL_ConfigPin(&PinCfg);
       #endif
-
+      CLKPWR_SetPCLKDiv(CLKPWR_PCLKSEL_UART2, CLKPWR_PCLKSEL_CCLK_DIV_1);
     } else if (UARTx == LPC_UART3) {
       // Initialize UART3 pin connect
       PinCfg.OpenDrain = 0;
@@ -171,7 +173,7 @@ public:
         PinCfg.Pinnum = 1;
         PINSEL_ConfigPin(&PinCfg);
       #endif
-
+      CLKPWR_SetPCLKDiv(CLKPWR_PCLKSEL_UART3, CLKPWR_PCLKSEL_CCLK_DIV_1);
     }
 
     /* Initialize UART Configuration parameter structure to default state:


### PR DESCRIPTION
Fix no response on Serial* for LPC1768 (SKR v1.3) with `BAUDRATE` > 250000
Fix no response on Serial* for LPC1769 (SKR v1.4 Turbo) with `BAUDRATE` >= 1000000

Fix derived from https://github.com/MarlinFirmware/Marlin/pull/22284 that was tested on Marlin with `SERIAL_PORT` 0 on SKR v1.3 and with `SERIAL_PORT` 0, 1, 3 on SKR v1.4 Turbo . With that fix verified 57600, 115200, 250000, 460800, 500000, 921600, 1000000 `BAUDRATE`s work.