### PR TITLE
Reduce SoftwareSerial priority and allow configuration through LPC_SERIAL_IRQ_PRIORITY

### DIFF
--- a/cores/arduino/SoftwareSerial.cpp
+++ b/cores/arduino/SoftwareSerial.cpp
@@ -35,7 +35,9 @@
 
 
 #define FORCE_BAUD_RATE 19200
-#define INTERRUPT_PRIORITY 0
+#ifndef LPC_SWSERIAL_IRQ_PRIORITY
+  #define LPC_SWSERIAL_IRQ_PRIORITY 1
+#endif
 #define OVERSAMPLE 3
 //
 // Statics
@@ -274,7 +276,7 @@ void SoftwareSerial::begin(long speed) {
   _speed = speed;
   if (!initialised) {
     RIT_Init(LPC_RIT);
-    NVIC_SetPriority(RIT_IRQn, NVIC_EncodePriority(0, INTERRUPT_PRIORITY, 0));
+    NVIC_SetPriority(RIT_IRQn, NVIC_EncodePriority(0, LPC_SWSERIAL_IRQ_PRIORITY, 0));
     initialised = true;
   }
   if (!_half_duplex) {


### PR DESCRIPTION
Reduce SoftwareSerial priority and allow configuration through LPC_SERIAL_IRQ_PRIORITY

Added option is similar in function and style to the existing LPC_UART_IRQ_PRIORITY define from HardwareSerial.

(edit, undid this: Comment out a FORCE_BAUD_RATE of 19200.)

Tested on LPC1768 (SKR v1.3) that it still communicated fine with some TMC2208 stepper drivers (which goes over SoftwareSerial).