### PR TITLE
Rename Sense_ASC::NONE to Sense_ASC::DISABLED to fix ODR warning

### DIFF
--- a/system/CMSIS/lib/usb/mscuser.h
+++ b/system/CMSIS/lib/usb/mscuser.h
@@ -53,7 +53,7 @@ enum struct Sense_KEY : uint8_t {
 };
 
 enum struct Sense_ASC : uint8_t {
-  NONE = 0x0,
+  DISABLED = 0x0,
   LOGICAL_UNIT_NOT_READY = 0x04,
   CANNOT_READ_MEDIUM = 0x30,
   MEDIUM_NOT_PRESENT = 0x3A,
@@ -83,7 +83,7 @@ struct Sense {
     reset();
   }
 
-  void set(Sense_KEY key_val, Sense_ASC asc_val = Sense_ASC::NONE, Sense_ASCQ ascq_val = Sense_ASCQ::REASON_UNKNOWN) {
+  void set(Sense_KEY key_val, Sense_ASC asc_val = Sense_ASC::DISABLED, Sense_ASCQ ascq_val = Sense_ASCQ::REASON_UNKNOWN) {
     key = key_val;
     asc = asc_val;
     ascq = ascq_val;
@@ -91,7 +91,7 @@ struct Sense {
 
   void reset() {
     key = Sense_KEY::NO_SENSE;
-    asc = Sense_ASC::NONE;
+    asc = Sense_ASC::DISABLED;
     ascq = Sense_ASCQ::REASON_UNKNOWN;
   }
 


### PR DESCRIPTION
Rename `Sense_ASC::NONE` to `Sense_ASC::DISABLED` to fix ODR warning

When compiling Marlin with `-flto`, gcc outputs some ODR warnings:

```
Linking .pio/build/LPC1769/firmware.elf
.platformio/packages/framework-arduino-lpc176x/system/CMSIS/lib/usb/mscuser.h:55:13: warning: type 'Sense_ASC' violates the C++ One Definition Rule [-Wodr]
   55 | enum struct Sense_ASC : uint8_t {
      |             ^
.platformio/packages/framework-arduino-lpc176x/system/CMSIS/lib/usb/mscuser.h:55:13: note: an enum with different value name is defined in another translation unit
   55 | enum struct Sense_ASC : uint8_t {
      |             ^
.platformio/packages/framework-arduino-lpc176x/system/CMSIS/lib/usb/mscuser.h:56:3: note: name 'DISABLED' differs from name 'NONE' defined in another translation unit
   56 |   NONE = 0x0,
      |   ^
.platformio/packages/framework-arduino-lpc176x/system/CMSIS/lib/usb/mscuser.h:56:3: note: mismatching definition
   56 |   NONE = 0x0,
      |   ^
```

This is a very confusing warning since gcc doesn't say anything else about the "another translation unit". It at least it says it's expecting `DISABLED` instead of `NONE` but I can't find any other Sense_ASC defined anywhere.

```
rgrep DISABLED
Binary file system/CMSIS/bin/libusbd_175x_6x_lib.a matches

rgrep Sense
Binary file system/CMSIS/bin/libusbd_175x_6x_lib.a matches
```

Binary files? In my open source?

Let's just `rm system/CMSIS/bin/libusbd_175x_6x_lib.a`. The rebuild notices something changed but there's still the ODR error and resulting final binary output does not change (same `sha256sum .pio/build/LPC1769/firmware.elf`). I guess `system/CMSIS/bin/libusbd_175x_6x_lib.a` is unnecessary, at least in (my?) Marlin build. But this doesn't help the ODR warning.

If you know how to find where the other definition is coming from I'd be quite interested. That said, this rename is simple enough to do (especially since there are no actual users of `NONE` from `Sense_ASC` I could find incl. through web searches) so I might as well offer it up as a PR.