### PR TITLE
Set cpu frequency based on F_CPU / board_build.f_cpu

### DIFF
--- a/system/CMSIS/system/system_LPC17xx.c
+++ b/system/CMSIS/system/system_LPC17xx.c
@@ -559,15 +559,17 @@ void SystemInit (void)
 
   LPC_SC->CCLKCFG   = 0x00000002;       /* Setup CPU Clock Divider            */
 
-  if(isLPC1769()) {
-    LPC_SC->PLL0CFG   = 0x0000000E;     /* configure PLL0                     */
-    LPC_SC->PLL0FEED  = 0xAA;
-    LPC_SC->PLL0FEED  = 0x55;
-  } else {
-    LPC_SC->PLL0CFG   = 0x00010018;     // 100MHz
-    LPC_SC->PLL0FEED  = 0xAA;
-    LPC_SC->PLL0FEED  = 0x55;
-  }
+  #if F_CPU == 96000000
+    LPC_SC->PLL0CFG = 0x0000000B;       /* configure PLL0                     */
+  #elif F_CPU == 100000000
+    LPC_SC->PLL0CFG = 0x00010018;
+  #elif F_CPU == 120000000 && MCU_LPC1769
+    LPC_SC->PLL0CFG = 0x0000000E;
+  #else
+    #error "The configured cpu frequency is not supported"
+  #endif
+  LPC_SC->PLL0FEED  = 0xAA;
+  LPC_SC->PLL0FEED  = 0x55;
 
   LPC_SC->PLL0CON   = 0x01;             /* PLL0 Enable                        */
   LPC_SC->PLL0FEED  = 0xAA;


### PR DESCRIPTION
Set cpu frequency based on F_CPU / platformio `board_build.f_cpu`. Fixes the potential pitfall where someone might try using `board_build.f_cpu` resulting in an `F_CPU` that differs from the one actually configured (through `LPC_SC->PLL0CFG`). `F_CPU` is used in `system/lpc176x/time.h` for the `delay*` functions and is also widely used in projects like Marlin.

Only allows 120mhz on MCU_LPC1769 and only the [most commonly configured frequencies](https://github.com/p3p/pio-framework-arduino-lpc176x/pull/54/files#diff-c6243def79553ee69a17b3458a24541756afe992f1229cc9d6ee64edbf211446R549).