### PR TITLE
Toggle should use output register, not pin state

### DIFF
--- a/system/lpc176x/pin_control.h
+++ b/system/lpc176x/pin_control.h
@@ -74,7 +74,7 @@ struct pin_type {
     return *reinterpret_cast<gpio_block*>(gpio_address());
   }
   [[gnu::always_inline]] inline void toggle() {
-    gpio_reg().reg_control ^= gpio_mask();
+    gpio_reg().reg_control = gpio_reg().reg_set ^ gpio_mask();
   }
   [[gnu::always_inline]] inline void set() {
     gpio_reg().reg_set = gpio_mask();


### PR DESCRIPTION
See discussion in https://github.com/MarlinFirmware/Marlin/issues/27341.

Function `pin_type::toggle()` reads a value from `gpio_reg().reg_control` (known as `FIOPIN` in the [LPC1768 manual](https://www.keil.com/dd/docs/datashts/philips/lpc17xx_um.pdf) chapter 9), modifies it and then writes it back to `gpio_reg().reg_control`. On writing, this updates the output register for GPIO. However the value read actually reads the pin state, not the output register.

It is possible when toggling pins in quick succession for a race condition to exist where a pin's output state is still reading an old value when `gpio_reg().reg_control` is read, resulting in lost pin changes.

To read the output register, one must read `gpio_reg().reg_set` (`FIOSET` in the LPC1768 manual).

I am not able to test this PR because I do not have an LPC1768 board but I have a report from https://github.com/MarlinFirmware/Marlin/issues/27341 that it works.